### PR TITLE
feat: restructure site with About as landing page and new Experience route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ npm run preview
 ## Architecture
 
 ### Tech Stack
+
 - **Framework**: SvelteKit 2.22.2 with Svelte 5
 - **Language**: TypeScript with strict mode enabled
 - **UI Components**: Sveltestrap (Bootstrap-based components)
@@ -51,7 +52,9 @@ npm run preview
 - **Build Tool**: Vite
 
 ### Svelte 5 Migration
+
 This project uses Svelte 5 with the Component API v4 compatibility setting. Key Svelte 5 patterns in use:
+
 - `$state()` for reactive state instead of `let` declarations
 - `$props()` for component props with TypeScript types
 - `{@render children?.()}` for slot rendering
@@ -77,7 +80,9 @@ src/
 ```
 
 ### Layout Architecture
+
 The root layout (`src/routes/+layout.svelte`) provides:
+
 - Sveltestrap styles via `<Styles />` component
 - Responsive navbar with mobile toggle
 - Main content area with 1024px max-width
@@ -85,17 +90,21 @@ The root layout (`src/routes/+layout.svelte`) provides:
 - Resume download link (from GitHub repository)
 
 ### Data Models
+
 Work experience data follows a structured model (see `WorkExperience.model.ts`):
+
 - `WE`: Top-level work experience type
   - `meta`: Contains title, company, image, url, and date range
   - `body`: Array of project accomplishments with title and description
 
 Portfolio projects are defined inline in `portfolio/+page.svelte` with:
+
 - Title, description, GitHub URL, live URL (optional), download URL (optional)
 - Tech stack array
 - Features array (with emoji prefixes)
 
 ### Styling Approach
+
 - Bootstrap classes via Sveltestrap components
 - Component-scoped styles in `<style>` blocks
 - Responsive design with mobile-first breakpoints
@@ -105,28 +114,35 @@ Portfolio projects are defined inline in `portfolio/+page.svelte` with:
 ## Important Notes
 
 ### TypeScript Configuration
+
 - Strict mode is enabled
 - `verbatimModuleSyntax` is set to true (import type syntax required)
 - Path aliases are handled by SvelteKit configuration
 
 ### Adapter Configuration
+
 The project uses `adapter-auto` in `svelte.config.js`, which auto-detects the deployment environment. Given the Vercel adapter is installed as a dependency, it will likely use that in production.
 
 ### Component API Compatibility
+
 The `svelte.config.js` sets `compatibility.componentApi: 4` to ensure Svelte 5 compatibility. When creating or modifying components, use Svelte 5 runes (`$state`, `$props`, `$derived`, etc.) rather than legacy patterns.
 
 ## Common Development Patterns
 
 ### Adding New Routes
+
 Create a new directory under `src/routes/` with `+page.svelte`. Use `+page.server.ts` for server-side logic if needed.
 
 ### Adding to Portfolio
+
 Edit `src/routes/portfolio/+page.svelte` and add new project objects to the `projects` array with the established structure.
 
 ### Updating Work Experience
+
 Edit `src/lib/workExperience.data.ts` to add or modify work experience entries. Follow the existing pattern with meta and body structure.
 
 ### Component Development
+
 - Use Svelte 5 runes for state management
 - Import Sveltestrap components from `@sveltestrap/sveltestrap`
 - Use TypeScript interfaces for props with the `Props` naming convention

--- a/flake.lock
+++ b/flake.lock
@@ -1,27 +1,27 @@
 {
-  "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1723221148,
-        "narHash": "sha256-7pjpeQlZUNQ4eeVntytU3jkw9dFK3k1Htgk2iuXjaD8=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "154bcb95ad51bc257c2ce4043a725de6ca700ef6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      }
-    }
-  },
-  "root": "root",
-  "version": 7
+	"nodes": {
+		"nixpkgs": {
+			"locked": {
+				"lastModified": 1723221148,
+				"narHash": "sha256-7pjpeQlZUNQ4eeVntytU3jkw9dFK3k1Htgk2iuXjaD8=",
+				"owner": "nixos",
+				"repo": "nixpkgs",
+				"rev": "154bcb95ad51bc257c2ce4043a725de6ca700ef6",
+				"type": "github"
+			},
+			"original": {
+				"owner": "nixos",
+				"ref": "nixpkgs-unstable",
+				"repo": "nixpkgs",
+				"type": "github"
+			}
+		},
+		"root": {
+			"inputs": {
+				"nixpkgs": "nixpkgs"
+			}
+		}
+	},
+	"root": "root",
+	"version": 7
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,6 +1,5 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
 	<head>
 		<meta charset="utf-8" />
 		<meta name="description" content="Hi, I'm Jordan!" />
@@ -12,5 +11,4 @@
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
-
 </html>

--- a/src/lib/WorkExperience.model.ts
+++ b/src/lib/WorkExperience.model.ts
@@ -1,22 +1,29 @@
 export type WE = {
-	meta: WEMeta
-	body: WEBody[]
-}
+	meta: WEMeta;
+	body: WEBody[];
+};
+
+export type WEPromotion = {
+	title: string;
+	date: string;
+};
 
 export type WEMeta = {
-	title: string
-	company: string
-	image: string
-	url: string
-	date: WEDate
-}
+	id: string;
+	title: string;
+	company: string;
+	image: string;
+	url: string;
+	date: WEDate;
+	promotions?: WEPromotion[];
+};
 
 export type WEBody = {
-	title: string
-	description: string
-}
+	title: string;
+	description: string;
+};
 
 export type WEDate = {
-	start: string
-	end: string
-}
+	start: string;
+	end: string;
+};

--- a/src/lib/WorkExperience.svelte
+++ b/src/lib/WorkExperience.svelte
@@ -20,7 +20,7 @@
 	let { workExperience }: Props = $props();
 </script>
 
-<div class="work-experience">
+<div class="work-experience" id={workExperience.meta.id}>
 	<Card class="work-experience-card">
 		<CardHeader class="work-experience-header">
 			<Row class="align-items-center">
@@ -37,6 +37,19 @@
 								{workExperience.meta.company}
 							</a>
 						</CardSubtitle>
+						{#if workExperience.meta.promotions && workExperience.meta.promotions.length > 0}
+							<div class="promotions">
+								{#each workExperience.meta.promotions as promotion, i}
+									<span class="promotion-item">
+										{promotion.title} ({promotion.date}){#if i < workExperience.meta.promotions.length - 1}<span
+												class="promotion-arrow"
+											>
+												→
+											</span>{/if}
+									</span>
+								{/each}
+							</div>
+						{/if}
 						<div class="employment-period">
 							<Badge color="secondary" class="date-badge">
 								{workExperience.meta.date.start} - {workExperience.meta.date.end}
@@ -133,6 +146,22 @@
 		text-decoration: underline;
 	}
 
+	.promotions {
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
+		font-size: 0.9rem;
+		color: #495057;
+		line-height: 1.6;
+	}
+
+	.promotion-item {
+		white-space: nowrap;
+	}
+
+	.promotion-arrow {
+		color: #6c757d;
+	}
+
 	.employment-period {
 		margin-top: 0.5rem;
 	}
@@ -188,6 +217,20 @@
 
 		:global(.company-name) {
 			font-size: 1rem;
+		}
+
+		.promotions {
+			font-size: 0.8rem;
+		}
+
+		.promotion-item {
+			display: block;
+			white-space: normal;
+		}
+
+		.promotion-arrow {
+			display: block;
+			margin: 0.25rem 0;
 		}
 
 		:global(.work-experience-header) {

--- a/src/lib/workExperience.data.ts
+++ b/src/lib/workExperience.data.ts
@@ -3,14 +3,20 @@ import type { WE } from './WorkExperience.model';
 export const workExperiences: WE[] = [
 	{
 		meta: {
-			title: 'Tech Lead Manager',
+			id: 'flosports',
+			title: 'Tech Lead, SRE',
 			company: 'FloSports',
 			image: 'https://www.flosports.tv/wp-content/uploads/2020/04/Hawk-ignite.png',
 			url: 'https://www.flosports.tv',
 			date: {
 				start: 'November 2019',
 				end: 'Present'
-			}
+			},
+			promotions: [
+				{ title: 'Infrastructure Engineer', date: '2019' },
+				{ title: 'Senior Infrastructure Engineer', date: '2021' },
+				{ title: 'Tech Lead, SRE', date: '2023' }
+			]
 		},
 		body: [
 			{
@@ -19,29 +25,30 @@ export const workExperiences: WE[] = [
 					'Led the migration of FloSports infrastructure to Kubernetes using Infrastructure as Code (IaC) with Terraform. Built comprehensive business case, scoped requirements, and implemented full CI/CD pipeline for cross-cloud deployment. Enabled ephemeral preview environments for rapid infrastructure testing and validation.'
 			},
 			{
-				title: 'Load Testing Platform',
+				title: 'Cloud Consolidation & Service Migration',
 				description:
-					'Architected and built a comprehensive load testing ecosystem using K6, GoReplay, and Kubernetes. Created containerized distributed load tests with ExpressJS backend, Node.js Kubernetes jobs, and RemixJS frontend. Enabled gameday validation and performance testing at scale.'
+					'Led multi-phase GCP to AWS migration for the entire platform in partnership with AWS MAP program. Migrated core monolith and 30+ services to EKS using DMS with zero downtime.'
 			},
 			{
-				title: 'Traffic Replay System',
+				title: 'Load Testing & Traffic Engineering',
 				description:
-					'Developed sophisticated traffic replay system using Istio, PubSub, BigQuery, GCS, and GoReplay. Captured and replayed production traffic against test environments with timestamp-based replay capabilities. Built Node.js job runner with advanced business logic for request replay and test data handling.'
+					'Architected distributed load testing platform on Kubernetes using K6 and GoReplay. Built traffic replay system using Istio, PubSub, and BigQuery for production traffic capture and replay. Validated readiness for major streaming events including ADCC and Wrestling Big Weekend. Currently building v2 leveraging the K6 Operator with a dedicated UI.'
 			},
 			{
-				title: 'Flo Deploy CLI',
+				title: 'Observability & Reliability',
 				description:
-					'Created streamlined deployment CLI using Node.js and Yargs, shipped as Google Cloud Build Builder. Leveraged Kustomize and custom templating system to enable one-command application deployments with standardized configuration management.'
+					'Established uptime baseline and SLOs across all FloSports platforms. Migrated to Datadog unified observability from fragmented stack (NewRelic, SignalFX, ELK). Built Datadog Scorecards for customer-impacting services.'
 			},
 			{
-				title: 'Observability Platform Migration',
+				title: 'SRE Team Transformation',
 				description:
-					'Spearheaded migration to Datadog unified observability platform from fragmented stack (NewRelic APM, SignalFX Metrics, ELK Logs). Significantly improved developer productivity through consolidated monitoring, alerting, and debugging capabilities.'
+					'Led transformation of Infrastructure Engineering team to Site Reliability Engineering, adopting principles from the Google SRE book. Established a code-first, developer productivity focused team with emphasis on stability and performance.'
 			}
 		]
 	},
 	{
 		meta: {
+			id: 'gm',
 			title: 'Big Data Platform Engineer',
 			company: 'General Motors',
 			image:
@@ -50,7 +57,11 @@ export const workExperiences: WE[] = [
 			date: {
 				start: 'May 2017',
 				end: 'November 2019'
-			}
+			},
+			promotions: [
+				{ title: 'L5 Big Data Platform Engineer', date: '2017' },
+				{ title: 'L6 Big Data Platform Engineer', date: '2019' }
+			]
 		},
 		body: [
 			{
@@ -72,6 +83,7 @@ export const workExperiences: WE[] = [
 	},
 	{
 		meta: {
+			id: 'lynntech',
 			title: 'Lab Technician',
 			company: 'Lynntech',
 			image: 'https://www.lynntech.com/wp-content/uploads/2016/04/HeaderLogo_Tiny.png',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,13 +34,13 @@
 		<div class="collapse navbar-collapse" class:show={isOpen}>
 			<Nav class="ms-auto" navbar>
 				<NavItem>
-					<NavLink href="/blog">Blog</NavLink>
+					<NavLink href="/experience">Experience</NavLink>
 				</NavItem>
 				<NavItem>
 					<NavLink href="/portfolio">Portfolio</NavLink>
 				</NavItem>
 				<NavItem>
-					<NavLink href="/about">About</NavLink>
+					<NavLink href="/blog">Blog</NavLink>
 				</NavItem>
 				<NavItem>
 					<NavLink href="/contact">Contact</NavLink>
@@ -63,13 +63,21 @@
 <footer>
 	<p>
 		<!-- Github link with github logo -->
-		<a href="https://github.com/jordangarrison" target="_blank" rel="noreferrer noopener" aria-label="GitHub Profile"
-			><i class="bi-github" role="img" aria-label="GitHub"></i></a
+		<a
+			href="https://github.com/jordangarrison"
+			target="_blank"
+			rel="noreferrer noopener"
+			aria-label="GitHub Profile"><i class="bi-github" role="img" aria-label="GitHub"></i></a
 		>
-		<a href="https://linkedin.com/in/jordan-garrison" target="_blank" rel="noreferrer noopener" aria-label="LinkedIn Profile"
-			><i class="bi bi-linkedin" aria-label="LinkedIn"></i></a
+		<a
+			href="https://linkedin.com/in/jordan-garrison"
+			target="_blank"
+			rel="noreferrer noopener"
+			aria-label="LinkedIn Profile"><i class="bi bi-linkedin" aria-label="LinkedIn"></i></a
 		>
-		<a href="mailto:hello@jordangarrison.dev" aria-label="Send Email"><i class="bi bi-envelope" aria-label="Email"></i></a>
+		<a href="mailto:hello@jordangarrison.dev" aria-label="Send Email"
+			><i class="bi bi-envelope" aria-label="Email"></i></a
+		>
 	</p>
 	<p>
 		&copy; {new Date().getFullYear()} <a href="https://jordangarrison.dev">jordangarrison.dev</a>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-	import { Col, Row, Image } from '@sveltestrap/sveltestrap';
-	import WorkExperience from '$lib/WorkExperience.svelte';
-	import { workExperiences } from '$lib/workExperience.data';
+	import { Card, CardBody, Badge, Row, Col, Image } from '@sveltestrap/sveltestrap';
 </script>
 
 <svelte:head>
-	<title>Hi I'm Jordan</title>
+	<title>Jordan Garrison</title>
 </svelte:head>
 
 <div class="page-container">
@@ -25,35 +23,171 @@
 			<Col xs={12} sm={6} md={8} lg={8}>
 				<div class="title">
 					<h1>Hi I'm Jordan</h1>
-					<h3>A Cloud Infrastructure Engineer</h3>
+					<h3>Engineer | Lifelong learner. Relentlessly curious.</h3>
 				</div>
 			</Col>
 		</Row>
 	</div>
 
-	<div class="work-experience-section">
-		<h2 class="section-title">My Work Experience</h2>
-		{#each workExperiences as workExperience}
-			<WorkExperience {workExperience} />
-		{/each}
-	</div>
+	<section class="intro-section">
+		<Card>
+			<CardBody>
+				<p class="intro-text">
+					Passionate about my family, Open Source, Linux, Jiu Jitsu, and being actively involved in
+					my local church.
+				</p>
+				<p class="philosophy">
+					<a href="https://grugbrain.dev" target="_blank" rel="noopener noreferrer"
+						>Complexity very bad. Say no to complexity.</a
+					>
+				</p>
+			</CardBody>
+		</Card>
+	</section>
+
+	<section class="journey-section">
+		<h2>My Journey</h2>
+		<div class="journey-timeline">
+			<div class="journey-item">
+				<div class="journey-year">2012-2017</div>
+				<div class="journey-content">
+					<strong>Texas A&M University</strong>
+					<p>
+						B.S. Physics with Math Minor. Started with Higgs Boson simulations in the Department of
+						Physics and Astronomy, running C++ and Bash on distributed computing clusters.
+					</p>
+				</div>
+			</div>
+			<a href="/experience#lynntech" class="journey-item journey-link">
+				<div class="journey-year">2016-2017</div>
+				<div class="journey-content">
+					<strong>Lynntech</strong>
+					<p>
+						Research Technician building IoT prototypes with Python, Arduino, and Raspberry Pi.
+						Hardware meets software.
+					</p>
+				</div>
+			</a>
+			<a href="/experience#gm" class="journey-item journey-link">
+				<div class="journey-year">2017-2019</div>
+				<div class="journey-content">
+					<strong>General Motors</strong>
+					<p>
+						Big Data Platform Engineer managing 15PB Hadoop clusters. Built monitoring systems,
+						security frameworks, and automation tools in Go and Python.
+					</p>
+				</div>
+			</a>
+			<a href="/experience#flosports" class="journey-item journey-link">
+				<div class="journey-year">2019-Present</div>
+				<div class="journey-content">
+					<strong>FloSports</strong>
+					<p>
+						From Infrastructure Engineer to Tech Lead, SRE. Building developer platforms, driving
+						cloud migrations, and establishing SRE practices.
+					</p>
+				</div>
+			</a>
+		</div>
+	</section>
+
+	<section class="skills-section">
+		<h2>Skills</h2>
+		<Row>
+			<Col md={6} class="mb-3">
+				<Card class="skill-card">
+					<CardBody>
+						<h4>Languages</h4>
+						<div class="skill-badges">
+							<Badge color="primary">Go</Badge>
+							<Badge color="primary">TypeScript</Badge>
+							<Badge color="primary">Python</Badge>
+							<Badge color="primary">Bash</Badge>
+							<Badge color="primary">Ruby</Badge>
+						</div>
+					</CardBody>
+				</Card>
+			</Col>
+			<Col md={6} class="mb-3">
+				<Card class="skill-card">
+					<CardBody>
+						<h4>Platforms</h4>
+						<div class="skill-badges">
+							<Badge color="secondary">Kubernetes</Badge>
+							<Badge color="secondary">Istio</Badge>
+							<Badge color="secondary">Argo</Badge>
+							<Badge color="secondary">Fastly</Badge>
+							<Badge color="secondary">Kafka</Badge>
+						</div>
+					</CardBody>
+				</Card>
+			</Col>
+			<Col md={6} class="mb-3">
+				<Card class="skill-card">
+					<CardBody>
+						<h4>Infrastructure as Code</h4>
+						<div class="skill-badges">
+							<Badge color="info">Terraform</Badge>
+							<Badge color="info">CDK</Badge>
+							<Badge color="info">Helm</Badge>
+							<Badge color="info">Kustomize</Badge>
+							<Badge color="info">Nix</Badge>
+						</div>
+					</CardBody>
+				</Card>
+			</Col>
+			<Col md={6} class="mb-3">
+				<Card class="skill-card">
+					<CardBody>
+						<h4>Observability</h4>
+						<div class="skill-badges">
+							<Badge color="warning">Datadog</Badge>
+							<Badge color="warning">Prometheus</Badge>
+							<Badge color="warning">Grafana</Badge>
+							<Badge color="warning">ELK</Badge>
+						</div>
+					</CardBody>
+				</Card>
+			</Col>
+		</Row>
+		<div class="linux-note">
+			<Card>
+				<CardBody>
+					<strong>Linux?</strong> Yes please! Especially love NixOS.
+				</CardBody>
+			</Card>
+		</div>
+	</section>
+
+	<section class="awards-section">
+		<h2>Awards & Certifications</h2>
+		<ul class="awards-list">
+			<li><strong>Advanced GitOps Certification</strong> - Akuity, 2024</li>
+			<li><strong>Promotion to Tech Lead</strong> - FloSports, 2023</li>
+			<li><strong>Top Performer - Own It Award</strong> - FloSports, 2021</li>
+			<li><strong>Promotion to Senior Infrastructure Engineer</strong> - FloSports, 2021</li>
+			<li><strong>CEO Life Saving Award & CIO Safety Award</strong> - General Motors, 2019</li>
+			<li><strong>Early Promotion from New College Hire Program</strong> - General Motors, 2019</li>
+			<li><strong>CIO Distinguished New College Hire</strong> - General Motors, 2018 & 2019</li>
+		</ul>
+	</section>
 </div>
 
 <style>
 	.page-container {
-		width: 100%;
-		max-width: 1200px;
+		padding: 1rem;
+		max-width: 900px;
 		margin: 0 auto;
-		padding: 2rem 1rem;
 	}
 
 	.hero-section {
-		margin-bottom: 4rem;
+		margin-bottom: 3rem;
+		margin-top: 2rem;
 	}
 
 	.profile-picture {
 		width: 100%;
-		max-width: 300px;
+		max-width: 250px;
 		margin: 0 auto;
 	}
 
@@ -76,40 +210,153 @@
 		margin-bottom: 0;
 	}
 
-	.work-experience-section {
-		margin-top: 2rem;
-	}
-
-	.section-title {
-		font-size: 2rem;
-		font-weight: 600;
-		color: #212529;
-		text-align: center;
+	section {
 		margin-bottom: 3rem;
-		position: relative;
 	}
 
-	.section-title::after {
+	section h2 {
+		font-size: 1.75rem;
+		font-weight: 600;
+		color: #333;
+		margin-bottom: 1.5rem;
+		padding-bottom: 0.5rem;
+		border-bottom: 2px solid #dee2e6;
+	}
+
+	.intro-section :global(.card) {
+		background: #f8f9fa;
+		border: none;
+	}
+
+	.intro-text {
+		font-size: 1.1rem;
+		line-height: 1.8;
+		color: #495057;
+		margin-bottom: 1rem;
+	}
+
+	.philosophy {
+		font-size: 1.2rem;
+		color: #333;
+		font-style: italic;
+	}
+
+	.philosophy a {
+		color: #0d6efd;
+		text-decoration: none;
+	}
+
+	.philosophy a:hover {
+		text-decoration: underline;
+	}
+
+	.journey-timeline {
+		position: relative;
+		padding-left: 2rem;
+		border-left: 3px solid #dee2e6;
+	}
+
+	.journey-item {
+		position: relative;
+		margin-bottom: 2rem;
+		padding-left: 1rem;
+		display: block;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.journey-link {
+		cursor: pointer;
+		transition: transform 0.2s ease;
+	}
+
+	.journey-link:hover {
+		transform: translateX(5px);
+	}
+
+	.journey-link:hover .journey-content strong {
+		color: #0d6efd;
+	}
+
+	.journey-item::before {
 		content: '';
 		position: absolute;
-		bottom: -10px;
-		left: 50%;
-		transform: translateX(-50%);
-		width: 80px;
-		height: 3px;
-		background: #6c757d;
-		border-radius: 2px;
+		left: -2.45rem;
+		top: 0.25rem;
+		width: 12px;
+		height: 12px;
+		background: #0d6efd;
+		border-radius: 50%;
+	}
+
+	.journey-year {
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: #6c757d;
+		margin-bottom: 0.25rem;
+	}
+
+	.journey-content strong {
+		font-size: 1.1rem;
+		color: #333;
+		transition: color 0.2s ease;
+	}
+
+	.journey-content p {
+		margin-top: 0.5rem;
+		margin-bottom: 0;
+		color: #495057;
+		line-height: 1.6;
+	}
+
+	:global(.skill-card) {
+		height: 100%;
+		border: 1px solid #dee2e6;
+	}
+
+	:global(.skill-card) h4 {
+		font-size: 1rem;
+		font-weight: 600;
+		margin-bottom: 0.75rem;
+		color: #333;
+	}
+
+	.skill-badges {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.linux-note {
+		margin-top: 1rem;
+	}
+
+	.linux-note :global(.card) {
+		background: #f8f9fa;
+		border: 1px dashed #dee2e6;
+		text-align: center;
+	}
+
+	.awards-list {
+		list-style: none;
+		padding: 0;
+	}
+
+	.awards-list li {
+		padding: 0.75rem 0;
+		border-bottom: 1px solid #eee;
+		color: #495057;
+	}
+
+	.awards-list li:last-child {
+		border-bottom: none;
+	}
+
+	.awards-list strong {
+		color: #333;
 	}
 
 	@media (max-width: 768px) {
-		.page-container {
-			padding: 1rem;
-		}
-
-		.title {
-			padding: 1rem 0;
-		}
-
 		.title h1 {
 			font-size: 2rem;
 		}
@@ -118,9 +365,12 @@
 			font-size: 1.25rem;
 		}
 
-		.section-title {
-			font-size: 1.5rem;
-			margin-bottom: 2rem;
+		.journey-timeline {
+			padding-left: 1.5rem;
+		}
+
+		.journey-item::before {
+			left: -1.95rem;
 		}
 	}
 </style>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-	import WorkInProgress from '$lib/workInProgress.svelte'
-</script>
-
-<WorkInProgress page="/about" />

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import WorkInProgress from '$lib/workInProgress.svelte'
+	import WorkInProgress from '$lib/workInProgress.svelte';
 </script>
 
 <WorkInProgress page="/blog" />

--- a/src/routes/experience/+page.svelte
+++ b/src/routes/experience/+page.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import WorkExperience from '$lib/WorkExperience.svelte';
+	import { workExperiences } from '$lib/workExperience.data';
+</script>
+
+<svelte:head>
+	<title>Experience - Jordan Garrison</title>
+</svelte:head>
+
+<div class="experience-container">
+	<div class="title">
+		<h1>Work Experience</h1>
+		<p class="lead">My professional journey through tech</p>
+	</div>
+
+	<div class="work-experience-section">
+		{#each workExperiences as workExperience}
+			<WorkExperience {workExperience} />
+		{/each}
+	</div>
+</div>
+
+<style>
+	.experience-container {
+		padding: 1rem;
+		max-width: 900px;
+		margin: 0 auto;
+	}
+
+	.title {
+		text-align: center;
+		margin-top: 50px;
+		margin-bottom: 50px;
+	}
+
+	.title h1 {
+		font-size: 2.5rem;
+		margin-bottom: 1rem;
+	}
+
+	.lead {
+		font-size: 1.2rem;
+		color: #6c757d;
+		margin-bottom: 0;
+	}
+
+	.work-experience-section {
+		margin-top: 2rem;
+	}
+
+	@media (max-width: 768px) {
+		.title h1 {
+			font-size: 2rem;
+		}
+
+		.lead {
+			font-size: 1rem;
+		}
+	}
+</style>

--- a/src/routes/portfolio/+page.svelte
+++ b/src/routes/portfolio/+page.svelte
@@ -1,59 +1,205 @@
 <script lang="ts">
-	import { Card, CardBody, CardHeader, Badge, Button, Row, Col } from '@sveltestrap/sveltestrap';
+	import {
+		Card,
+		CardBody,
+		CardHeader,
+		Badge,
+		Button,
+		Row,
+		Col,
+		Nav,
+		NavItem,
+		NavLink
+	} from '@sveltestrap/sveltestrap';
 
-	const projects = [
+	let activeFilter = $state('all');
+
+	// Tools (CLI/DevOps)
+	const toolsProjects = [
 		{
 			id: 1,
-			title: "hubctl",
-			description: "A comprehensive, production-ready CLI tool for GitHub administration with full API integration, multiple output formats, interactive prompts, and beautiful error handling.",
-			githubUrl: "https://github.com/jordangarrison/hubctl",
+			title: 'yoink',
+			description:
+				'Automatically revoke exposed credentials before they can be exploited. A security automation tool with a plugin architecture for credential detection and revocation.',
+			githubUrl: 'https://github.com/jordangarrison/yoink',
 			liveUrl: null,
-			downloadUrl: "https://github.com/jordangarrison/hubctl/releases/latest",
-			techStack: ["Ruby", "Thor", "Octokit", "TTY-Prompt", "TTY-Table", "TTY-Spinner", "Pastel"],
+			downloadUrl: 'https://github.com/jordangarrison/yoink/releases/latest',
+			techStack: ['Go', 'Plugin Architecture', 'Security'],
 			features: [
-				"🚀 Full GitHub API integration (Octokit)",
-				"🎨 Multiple output formats: table, JSON, list",
-				"🛡️ Comprehensive error handling with helpful messages",
-				"🎯 Interactive prompts and confirmation dialogs",
-				"⚡ Loading spinners for long-running operations",
-				"🔐 Flexible authentication via env vars or config file",
-				"🔄 Batch operations and scripting-friendly design"
+				'Automatic credential detection',
+				'Plugin-based revocation engines',
+				'Multiple credential type support',
+				'CI/CD integration ready',
+				'Extensible architecture'
 			]
 		},
 		{
 			id: 2,
-			title: "Let Me GPT That For You",
-			description: "A modern clone of 'Let me Google that for you' but for AI chat interfaces! Create shareable links that demonstrate different AI providers (ChatGPT, Gemini, Claude) with custom questions.",
-			githubUrl: "https://github.com/jordangarrison/let-me-gpt-that-for-you",
-			liveUrl: "https://www.lmgpt4u.com/",
-			techStack: ["SvelteKit", "TypeScript", "TailwindCSS", "DaisyUI", "Vercel"],
+			title: 'hubctl',
+			description:
+				'A comprehensive CLI tool for GitHub Enterprise administration with full API integration, multiple output formats, and interactive prompts.',
+			githubUrl: 'https://github.com/jordangarrison/hubctl',
+			liveUrl: null,
+			downloadUrl: 'https://github.com/jordangarrison/hubctl/releases/latest',
+			techStack: ['Ruby', 'Thor', 'Octokit', 'TTY'],
 			features: [
-				"🤖 Support for multiple AI providers (ChatGPT, Gemini, Claude)",
-				"🔗 Generate unique shareable URLs for each query",
-				"💬 Realistic chat interface simulation",
-				"📱 Responsive design with modern UI",
-				"⚡ Built with SvelteKit for fast performance",
-				"🚀 Ready for Vercel deployment"
+				'Full GitHub API integration',
+				'Multiple output formats: table, JSON, list',
+				'Interactive prompts and confirmations',
+				'Batch operations support',
+				'Enterprise-ready authentication'
 			]
 		},
 		{
 			id: 3,
-			title: "What's My Status?",
-			description: "Multi-platform CLI tool that allows you to set your status on multiple platforms (Slack, GitHub) at once from the command line.",
-			githubUrl: "https://github.com/jordangarrison/whats-my-status",
+			title: 'whats-my-status',
+			description:
+				'Multi-platform CLI tool to set your status on Slack and GitHub simultaneously from the command line.',
+			githubUrl: 'https://github.com/jordangarrison/whats-my-status',
 			liveUrl: null,
-			downloadUrl: "https://github.com/jordangarrison/whats-my-status/releases/latest",
-			techStack: ["Go", "CLI", "YAML"],
+			downloadUrl: 'https://github.com/jordangarrison/whats-my-status/releases/latest',
+			techStack: ['Go', 'CLI', 'YAML'],
 			features: [
-				"🚀 Multi-platform support (Windows, macOS, Linux)",
-				"💬 Slack workspace status management",
-				"🐙 GitHub user status integration",
-				"⚡ Custom status aliases for quick setup",
-				"⏰ Time-based status expiration",
-				"🔧 YAML-based configuration"
+				'Multi-platform support (Windows, macOS, Linux)',
+				'Slack and GitHub status sync',
+				'Custom status aliases',
+				'Time-based expiration',
+				'YAML configuration'
 			]
 		}
 	];
+
+	// Nix Ecosystem
+	const nixProjects = [
+		{
+			id: 4,
+			title: 'nix-config',
+			description:
+				'My personal NixOS configurations for reproducible system setups across all my machines. Declarative, version-controlled infrastructure for personal computing.',
+			githubUrl: 'https://github.com/jordangarrison/nix-config',
+			liveUrl: null,
+			downloadUrl: null,
+			techStack: ['Nix', 'NixOS', 'Home Manager', 'Flakes'],
+			features: [
+				'Fully declarative system configuration',
+				'Reproducible across machines',
+				'Home Manager integration',
+				'Flakes-based architecture',
+				'Development environment shells'
+			]
+		},
+		{
+			id: 5,
+			title: 'nix-packages',
+			description:
+				'Custom Nix packages and overlays for software not yet in nixpkgs or requiring custom configurations.',
+			githubUrl: 'https://github.com/jordangarrison/nix-packages',
+			liveUrl: null,
+			downloadUrl: null,
+			techStack: ['Nix', 'Flakes', 'Packaging'],
+			features: [
+				'Custom package definitions',
+				'Flakes-based distribution',
+				'Easy to consume as overlay',
+				'Reproducible builds'
+			]
+		},
+		{
+			id: 6,
+			title: 'warp-preview-flake',
+			description:
+				'Warp Terminal (preview) packaged from .deb for NixOS. Bringing modern terminal tools to the Nix ecosystem.',
+			githubUrl: 'https://github.com/jordangarrison/warp-preview-flake',
+			liveUrl: null,
+			downloadUrl: null,
+			techStack: ['Nix', 'Flakes', 'Packaging'],
+			features: [
+				'Warp Terminal on NixOS',
+				'Automated .deb extraction',
+				'Flake-based installation',
+				'Preview version tracking'
+			]
+		},
+		{
+			id: 7,
+			title: 'aws-tools',
+			description:
+				'A collection of CLI utilities for working with AWS services, packaged with Nix for reproducible environments.',
+			githubUrl: 'https://github.com/jordangarrison/aws-tools',
+			liveUrl: null,
+			downloadUrl: null,
+			techStack: ['Python', 'AWS', 'Nix', 'CLI'],
+			features: [
+				'Multiple AWS service utilities',
+				'Nix-packaged for reproducibility',
+				'SSO-friendly workflows',
+				'Scripting-ready design'
+			]
+		},
+		{
+			id: 8,
+			title: 'aws-use-sso',
+			description:
+				'Small utility to export AWS environment variables to your shell in an SSO environment.',
+			githubUrl: 'https://github.com/jordangarrison/aws-use-sso',
+			liveUrl: null,
+			downloadUrl: null,
+			techStack: ['Nix', 'AWS', 'SSO', 'Shell'],
+			features: [
+				'AWS SSO integration',
+				'Environment variable export',
+				'Shell-friendly output',
+				'Nix flake packaging'
+			]
+		}
+	];
+
+	// AI & Fun
+	const aiProjects = [
+		{
+			id: 9,
+			title: 'agents',
+			description:
+				'Personal micro agents for productivity. Agentic tools are the new dotfiles - small, composable AI-powered utilities for everyday tasks.',
+			githubUrl: 'https://github.com/jordangarrison/agents',
+			liveUrl: null,
+			downloadUrl: null,
+			techStack: ['TypeScript', 'AI', 'Claude', 'MCP'],
+			features: [
+				'Composable micro agents',
+				'AI-powered productivity tools',
+				'Personal automation workflows',
+				'MCP integration',
+				'Extensible design'
+			]
+		},
+		{
+			id: 10,
+			title: 'let-me-gpt-that-for-you',
+			description:
+				"A clone of 'Let me Google that for you' but for AI chats. Create shareable links with pre-filled prompts for ChatGPT, Gemini, and Claude.",
+			githubUrl: 'https://github.com/jordangarrison/let-me-gpt-that-for-you',
+			liveUrl: 'https://www.lmgpt4u.com/',
+			downloadUrl: null,
+			techStack: ['SvelteKit', 'TypeScript', 'TailwindCSS', 'Vercel'],
+			features: [
+				'Multiple AI providers supported',
+				'Shareable pre-filled prompt links',
+				'Realistic chat simulation',
+				'Responsive modern UI'
+			]
+		}
+	];
+
+	const projectGroups = [
+		{ key: 'tools', title: 'Tools', projects: toolsProjects },
+		{ key: 'nix', title: 'Nix Ecosystem', projects: nixProjects },
+		{ key: 'ai', title: 'AI & Fun', projects: aiProjects }
+	];
+
+	const filteredGroups = $derived(
+		activeFilter === 'all' ? projectGroups : projectGroups.filter((g) => g.key === activeFilter)
+	);
 </script>
 
 <svelte:head>
@@ -66,72 +212,95 @@
 		<p class="lead">A collection of projects I've built and deployed</p>
 	</div>
 
+	<div class="filter-tabs">
+		<Nav tabs>
+			<NavItem>
+				<NavLink active={activeFilter === 'all'} href="#" onclick={() => (activeFilter = 'all')}>
+					All
+				</NavLink>
+			</NavItem>
+			{#each projectGroups as group}
+				<NavItem>
+					<NavLink
+						active={activeFilter === group.key}
+						href="#"
+						onclick={() => (activeFilter = group.key)}
+					>
+						{group.title}
+					</NavLink>
+				</NavItem>
+			{/each}
+		</Nav>
+	</div>
+
 	<div class="projects">
-		{#each projects as project}
-			<Card class="mb-4 project-card">
-				<CardHeader>
-					<h2 class="project-title">{project.title}</h2>
-				</CardHeader>
-				<CardBody>
-					<p class="project-description">{project.description}</p>
-					
-					<div class="features-section">
-						<h4>Features:</h4>
-						<ul class="features-list">
-							{#each project.features as feature}
-								<li>{feature}</li>
-							{/each}
-						</ul>
-					</div>
+		{#each filteredGroups as group}
+			<div class="project-group">
+				<h3 class="group-title">{group.title}</h3>
+				{#each group.projects as project}
+					<Card class="mb-3 project-card">
+						<CardHeader>
+							<h4 class="project-title">{project.title}</h4>
+						</CardHeader>
+						<CardBody>
+							<p class="project-description">{project.description}</p>
 
-					<div class="tech-stack">
-						<h4>Tech Stack:</h4>
-						<div class="badges">
-							{#each project.techStack as tech}
-								<Badge color="secondary" class="me-1 mb-1">{tech}</Badge>
-							{/each}
-						</div>
-					</div>
+							<div class="features-section">
+								<h5>Features:</h5>
+								<ul class="features-list">
+									{#each project.features as feature}
+										<li>{feature}</li>
+									{/each}
+								</ul>
+							</div>
 
-					<Row class="mt-3">
-						<Col>
-							<Button 
-								color="primary" 
-								outline 
-								href={project.githubUrl} 
-								target="_blank" 
-								rel="noopener noreferrer"
-								class={(project.liveUrl || project.downloadUrl) ? "me-2" : ""}
-							>
-								<i class="bi bi-github me-1"></i>
-								View Source
-							</Button>
-							{#if project.liveUrl}
-								<Button 
-									color="success" 
-									href={project.liveUrl} 
-									target="_blank" 
-									rel="noopener noreferrer"
-								>
-									<i class="bi bi-box-arrow-up-right me-1"></i>
-									Live Demo
-								</Button>
-							{/if}
-							{#if project.downloadUrl}
-								<Button 
-									color="info" 
-									href={project.downloadUrl} 
-									target="_blank" 
-									rel="noopener noreferrer"
-								>
-									<i class="bi bi-download me-1"></i>
-									Download
-								</Button>
-							{/if}
-						</Col>
-					</Row>
-				</CardBody>
-			</Card>
+							<div class="tech-stack">
+								<h5>Tech Stack:</h5>
+								<div class="badges">
+									{#each project.techStack as tech}
+										<Badge color="secondary" class="me-1 mb-1">{tech}</Badge>
+									{/each}
+								</div>
+							</div>
+
+							<Row class="mt-3">
+								<Col>
+									<Button
+										color="primary"
+										outline
+										href={project.githubUrl}
+										target="_blank"
+										rel="noopener noreferrer"
+										class={project.liveUrl || project.downloadUrl ? 'me-2' : ''}
+									>
+										View Source
+									</Button>
+									{#if project.liveUrl}
+										<Button
+											color="success"
+											href={project.liveUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											Live Demo
+										</Button>
+									{/if}
+									{#if project.downloadUrl}
+										<Button
+											color="info"
+											href={project.downloadUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											Download
+										</Button>
+									{/if}
+								</Col>
+							</Row>
+						</CardBody>
+					</Card>
+				{/each}
+			</div>
 		{/each}
 	</div>
 </div>
@@ -171,15 +340,32 @@
 		width: 100%;
 	}
 
+	.filter-tabs {
+		margin-bottom: 2rem;
+	}
+
+	.project-group {
+		margin-bottom: 2.5rem;
+	}
+
+	.group-title {
+		font-size: 1.5rem;
+		font-weight: 600;
+		color: #333;
+		margin-bottom: 1rem;
+		padding-bottom: 0.5rem;
+		border-bottom: 2px solid #dee2e6;
+	}
+
 	:global(.project-card) {
 		border: 1px solid #eaeaea;
 		border-radius: 8px;
-		box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 		transition: box-shadow 0.3s ease;
 	}
 
 	:global(.project-card:hover) {
-		box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+		box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 	}
 
 	.project-title {
@@ -199,7 +385,7 @@
 		margin-bottom: 1.5rem;
 	}
 
-	.features-section h4 {
+	.features-section h5 {
 		font-size: 1.1rem;
 		margin-bottom: 0.5rem;
 		color: #333;
@@ -221,7 +407,7 @@
 		margin-bottom: 1rem;
 	}
 
-	.tech-stack h4 {
+	.tech-stack h5 {
 		font-size: 1.1rem;
 		margin-bottom: 0.5rem;
 		color: #333;
@@ -237,10 +423,9 @@
 		.title h1 {
 			font-size: 2rem;
 		}
-		
+
 		.lead {
 			font-size: 1rem;
 		}
 	}
 </style>
-


### PR DESCRIPTION
## Summary

- Move About page content to home page with hero, intro, journey timeline, skills, and awards
- Create new `/experience` route for detailed work history with anchor links
- Update navigation: remove About, add Experience link
- Update portfolio with grouped projects (Tools, Nix Ecosystem, AI & Fun) and filter tabs
- Add promotions tracking to work experience model

## Test plan

- [x] Verify home page displays hero, intro, journey timeline, skills, and awards
- [x] Verify `/experience` route shows all work history entries
- [x] Verify journey links (`/experience#flosports`, `/experience#gm`, `/experience#lynntech`) scroll to correct sections
- [x] Verify navigation shows Experience | Portfolio | Blog | Contact | Resume
- [x] Verify portfolio filter tabs work correctly
- [x] Verify promotions display correctly on experience page