### PR TITLE
feat: add greenlight to portfolio

### DIFF
--- a/src/lib/portfolio.data.ts
+++ b/src/lib/portfolio.data.ts
@@ -87,6 +87,23 @@ export const toolsProjects: PortfolioProject[] = [
 			'Automatic model downloading and management',
 			'XDG-compliant configuration with Nix flake packaging'
 		]
+	},
+	{
+		id: 15,
+		title: 'greenlight',
+		description:
+			'GitHub Actions workflow visualizer built with Phoenix LiveView. View CI/CD pipelines as interactive DAGs.',
+		githubUrl: 'https://github.com/jordangarrison/greenlight',
+		liveUrl: null,
+		downloadUrl: null,
+		techStack: ['Elixir', 'Phoenix LiveView', 'Svelte', 'Nix'],
+		features: [
+			'Interactive DAG visualization of workflows',
+			'Real-time polling of workflow run status',
+			'Expandable job nodes with dependency graphs',
+			'Dashboard for followed orgs and bookmarked repos',
+			'Pipeline view per commit with dependency resolution'
+		]
 	}
 ];
 


### PR DESCRIPTION
## Summary
- Add **greenlight** (GitHub Actions workflow visualizer) to the Tools portfolio category
- Synced from GitHub pinned repos - the only pinned repo not yet in the portfolio
- Other pinned repos (wiggle-puppy, panko) were already added in a previous update

## Test plan
- [ ] Run `npm run check` - type checking passes
- [ ] Verify greenlight appears in the Tools category on the portfolio page
- [ ] Verify category filtering still works correctly