### PR TITLE
feat: add blog post on shared stability responsibility

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,7 +8,7 @@ const blog = defineCollection({
     title: z.string(),
     date: z.coerce.date(),
     excerpt: z.string(),
-    categories: z.array(z.enum(['engineering', 'nix', 'devops', 'personal', 'tutorial'])),
+    categories: z.array(z.enum(['engineering', 'nix', 'personal', 'tutorial'])),
     tags: z.array(z.string()),
     published: z.boolean(),
     readingTime: z.string(),

--- a/src/content/blog/reframing-stability-as-shared-responsibility.md
+++ b/src/content/blog/reframing-stability-as-shared-responsibility.md
@@ -1,0 +1,78 @@
+---
+title: "Reframing Stability as a Shared Responsibility"
+date: "2025-02-06"
+categories: ["engineering"]
+tags: ["reliability", "sre", "engineering-culture", "product-engineering", "stability", "leadership"]
+excerpt: "Stability shouldn't be solely an engineering burden. By shifting accountability and embedding reliability into the product development lifecycle, organizations can ensure that innovation and reliability go hand in hand."
+published: true
+readingTime: "9 min read"
+---
+
+# Reframing Stability as a Shared Responsibility: Ensuring Product Teams Own Reliability
+
+During a management meeting at work, we reviewed the results of a developer satisfaction survey. One of our engineers, with their manager's support, had initiated an organization-wide anonymous survey covering topics from company culture to technical challenges and workload. A recurring theme emerged, one that many managers had underestimated: growing frustration over the relentless push for new product features while critical core systems suffered from ongoing stability issues. This imbalance was leading to increased unpaid overtime, rising attrition of senior staff, and widespread burnout.
+
+At its core, this was not just a technical problem. It was a cultural issue embedded in how decisions were made. The management team felt powerless to enact meaningful change because the real problem stemmed from the product team's willingness to say "yes" to every request the business threw their way. However, this wasn't simply a matter of poor prioritization; it was a direct result of how progress was measured. Objectives and key results (OKRs) were tightly coupled to the number of features shipped, and investor expectations were set based on this relentless pace. The pressure to continually demonstrate growth led to a system where declining new initiatives was seen as failure rather than strategic discipline.
+
+The core issue was not just the volume of requests but the mindset behind them. The product team was focused on launching new features without considering the long-term operational cost of maintaining them. There was little to no emphasis on planning beyond the initial release. Questions about scalability, monitoring, and ongoing support were rarely addressed upfront. As a result, engineering teams were left to deal with the long tail of these decisions, ensuring the stability of hastily released features while still keeping up with the ever-growing backlog of new demands.
+
+Without a fundamental shift in how product teams balanced business needs against long-term technical health, and without a realignment of how success was defined at an organizational level, the cycle of instability, burnout, and attrition would continue unabated.
+
+<aside class="pullquote">Stability must not be a secondary concern; it must be a shared responsibility across the organization.</aside>
+
+One of the most persistent challenges in engineering is maintaining system stability and reliability while simultaneously meeting demands for rapid feature development. Too often, engineering teams bear the sole responsibility for mitigating risk, while product teams focus exclusively on new capabilities. However, stability should not be treated as a secondary concern; it must be a shared responsibility across the organization. The key to achieving this balance lies in shifting accountability and ensuring that product teams actively participate in maintaining reliability. Here's how to make that happen.
+
+## The Importance of Pushing Back
+
+Engineers often feel pressure to deliver new features as quickly as possible, even when doing so introduces long-term risks. However, effective engineering organizations recognize that part of their responsibility is pushing back against unrealistic expectations or unsustainable development practices. Pushing back isn't about resisting change. It's about advocating for thoughtful, strategic decisions that balance short-term product needs with long-term system health.
+
+A key part of this strategy is ensuring that product teams share responsibility for system reliability. That means shifting the burden of proof to those requesting new features and requiring them to justify how their changes will maintain stability.
+
+## Establishing a "Proof of No Harm" Standard
+
+Too often, the conversation around stability is reactive. Engineers find themselves justifying why a proposed feature might introduce instability, and those warnings are easy to dismiss as hypothetical. We found it far more effective to flip the burden of proof: instead of engineers proving the _cost_ of instability, require product teams to demonstrate that a feature _will not_ degrade system reliability.
+
+This reframing changes the entire dynamic. When the default expectation is that new features must prove they won't cause harm, stability concerns get addressed at the design stage rather than after an incident. In practice, we formalized this through three concrete requirements before any feature could be approved for launch:
+
+- **Pre-deployment stability impact assessments.** Teams must analyze and document the potential risks a new feature introduces to production systems before it ships. This forces a conversation about operational cost upfront, not after the damage is done.
+- **Rollback mechanisms as a prerequisite for launch.** Every feature needs a tested rollback strategy. If you can't undo it safely, it's not ready to ship. This simple gate eliminated a class of incidents where teams had no way to quickly revert a bad deploy.
+- **Automated regression testing for core functionality.** New features should not silently break existing behavior. Requiring automated test coverage for regressions ensures that the cost of moving fast doesn't compound over time.
+
+The goal is not to slow teams down but to ensure that new features add value without eroding the reliability of what already exists. By embedding these expectations early in the development cycle, stability becomes a proactive requirement rather than a reactive afterthought.
+
+## From "If" to "When": Framing Reliability as an Inevitable Concern
+
+Risk assessments often take the form of hypothetical warnings: "If this breaks, it will cause major issues." This framing is ineffective because it allows decision-makers to discount the likelihood of failure. Instead, shift the language to reflect reality: _"When this fails, who is responsible, and how will they handle the resolution?"_ By treating instability as an eventuality rather than a possibility, you create a structured framework for accountability.
+
+To operationalize this mindset, require explicit ownership for all deployed features. Maintain clear on-call designations for each component and ensure accountability extends beyond the engineering team. If a feature is essential enough to justify development, it should also warrant proper operational support.
+
+One of the most effective tools for making this concrete is the service-level objective (SLO). The key insight is that SLOs should not be defined around infrastructure metrics like CPU or memory. They should be defined around user journeys: can a subscriber start a live stream? Can a user complete a purchase? These are the outcomes that actually matter to the business. When SLOs are framed this way, the product manager who owns that user journey naturally becomes accountable for the reliability outcomes tied to it. They're no longer just shipping features into a void; they're responsible for ensuring their product area stays healthy for the people who use it. This creates a direct feedback loop between product decisions and their operational consequences, which is exactly the kind of shared ownership that prevents stability from being treated as someone else's problem.
+
+## Integrating Stability into the Definition of "Done"
+
+A feature is not complete simply because the core functionality works as expected. Stability, scalability, and resilience must be included in the definition of "done" to prevent technical debt from accumulating unchecked. Ensure that acceptance criteria encompass performance baselines, fault tolerance measures, and incident resolution plans.
+
+The ideal state is reinforcing this through automated quality gates, where deployments are blocked if key stability benchmarks are not met. In practice, getting there is hard. It requires agreement on what those benchmarks are, tooling to measure them consistently, and organizational willingness to accept that a blocked deploy is a feature, not a failure. We're still working toward this ourselves, but the direction matters: every step toward treating reliability as a first-class quality signal, even imperfect ones, moves the culture away from treating it as an afterthought.
+
+## Cultivating Organizational Buy-In for Stability Initiatives
+
+
+Convincing product teams to prioritize stability can be difficult, but it becomes easier when other parts of the organization reinforce the message. Identifying and engaging allies across different functions can amplify the urgency of reliability concerns.
+
+### Customer Support as a Strategic Partner
+
+Support teams have direct visibility into customer frustrations, making them invaluable allies in advocating for stability. Establish a continuous feedback loop between support and engineering, using real-world customer complaints to highlight the impact of system instability. By presenting concrete examples of how reliability issues lead to churn, escalations, and lost revenue, you can make a compelling case for prioritizing stability over unchecked feature expansion.
+
+### Cross-Functional Stability Councils
+
+Stability problems rarely live within a single team. When reliability issues surface across multiple areas, it's a signal that the organization needs a shared forum to address them. Consider forming a cross-team stability council with representatives from engineering, product, and support. This group can establish shared best practices, review incident postmortems together, and develop organization-wide reliability standards.
+
+The value of this kind of council isn't just the practices it produces. When a single team raises stability concerns, it's easy to dismiss them as resistant to change or overly cautious. A cross-functional group carries more weight because the concern is clearly shared, not siloed. But more importantly, it creates shared context. When product managers sit alongside engineers reviewing what went wrong in an incident, the tradeoffs become tangible. When support shares the customer impact data alongside the technical root cause, everyone is working from the same picture. Institutionalizing stability as a collaborative effort across functions ensures it stays a core priority rather than a concern that only surfaces when something breaks.
+
+## The Long-Term Costs of Instability: Why Reliability Matters
+
+Ultimately, an unreliable product, even one packed with innovative features, will struggle to retain users. Customers expect consistency, and persistent instability damages trust. Worse still, instability has a compounding effect: it increases support costs, slows development cycles, and drains engineering resources as teams are forced to address repeated failures instead of building new capabilities.
+
+Leaders need to recognize that investing in stability is not a cost. It is a prerequisite for sustainable growth. When systems fail, it is not simply an engineering problem; it is a business risk. By integrating reliability into the product development lifecycle, shifting accountability to product teams, and fostering cross-functional advocacy for stability, organizations can ensure that innovation and reliability go hand in hand.
+
+Prioritizing stability is not about stifling progress. It is about ensuring that progress leads to lasting success. By embedding stability considerations at every stage of development, companies can build not just bigger products, but better ones.

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -159,6 +159,21 @@ const formattedDate = frontmatter.date.toLocaleDateString('en-US', {
       font-style: italic;
     }
 
+    /* Pullquotes — magazine-style callout */
+    & aside.pullquote {
+      border-top: 3px solid var(--rp-rose);
+      border-bottom: 3px solid var(--rp-rose);
+      margin: 2rem auto;
+      padding: 1.5rem 2rem;
+      font-size: 1.3rem;
+      line-height: 1.6;
+      font-style: italic;
+      font-weight: 500;
+      color: var(--rp-iris);
+      text-align: center;
+      max-width: 85%;
+    }
+
     /* Horizontal rules */
     & hr {
       border-color: var(--rp-highlight-med);


### PR DESCRIPTION
## Summary

- Adds new blog post "Reframing Stability as a Shared Responsibility" adapted from internal Confluence content
- Adds magazine-style pullquote (`aside.pullquote`) CSS to the blog post layout for callout blurbs
- Removes unused `devops` category from the blog content schema

## Test plan

- [ ] Verify blog post renders correctly at `/blog/reframing-stability-as-shared-responsibility/`
- [ ] Verify pullquote displays with rose borders and iris text, centered between paragraphs
- [ ] Verify blog index shows the post with `engineering` category filter
- [ ] Verify production build passes (`bun run build`)