### PR TITLE
feat(portfolio): add focus-fox from pinned repos

### DIFF
--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -91,6 +91,17 @@ export const toolsProjects: PortfolioProject[] = [
 		techStack: ['Clojure', 'ClojureScript', 'shadow-cljs', 'Babashka', 'Nix'],
 		features: ['Lisp surface for declaring C4-aligned diagrams', 'Single .cljc core targets browser SPA, Babashka CLI, and JVM library', 'Multiple emitters: graphviz dot, mermaid C4, Excalidraw', 'Level inference (context/container/component) with at-level filtering', 'Live browser preview with CodeMirror 6 + paredit editing', 'NixOS module for self-hosting the SPA'],
 		pinned: true
+	},
+	{
+		id: 17,
+		title: 'focus-fox',
+		description: 'Terminal-based pomodoro timer with work sessions, short breaks, and long breaks, featuring a big clock and a progress ring with a fox in the middle.',
+		githubUrl: 'https://github.com/jordangarrison/focus-fox',
+		liveUrl: null,
+		downloadUrl: null,
+		techStack: ['Rust', 'Ratatui', 'TUI', 'Nix'],
+		features: ['Configurable work, short break, and long break intervals', 'Big clock with a progress ring and fox animation', 'Desktop notifications on phase transitions', 'TUI config menu with vim-style keys, persisted to config.toml', 'Pause, skip, and restart controls mid-session', 'Nix flake packaging with notify-send wrapped onto PATH'],
+		pinned: true
 	}
 ];
 


### PR DESCRIPTION
## Summary

Ran `/sync-portfolio` to sync the portfolio page with GitHub pinned repos. Of the 6 pinned repos, five were already present with no changes; **focus-fox** was new and has been added to the Tools category.

- **focus-fox** (new, id 17, pinned) — terminal-based pomodoro timer built with Rust + Ratatui. Features generated from its README.

Unchanged pinned repos: nix-config (nix), greenlight (tools), sweet-nothings (tools), panko (ai), wiggle-puppy (ai).

## Notes

- **sweet-nothings** has a `nixos` topic that the routing rules would map to the `nix` category, but it is fundamentally a dictation CLI and was already in `tools`, so it was left there.
- **sweet-nothings** reports a `homepageUrl` equal to its own GitHub URL (not a real live site), so `liveUrl` stays null.

## Testing

- `bun run check` — 0 errors, 0 warnings, 0 hints

https://claude.ai/code/session_01DYtY4RFUddhtm5Lmuqcge2